### PR TITLE
Add advanced news search, long-press actions, and API docs

### DIFF
--- a/SCOMBZ_API.md
+++ b/SCOMBZ_API.md
@@ -1,0 +1,422 @@
+# ScombZ Mobile API仕様
+
+この文書は、SUKOMBUが扱うScombZ Mobile APIの非公式仕様です。サーバー側の変更により、予告なく利用できなくなる可能性があります。
+
+認証情報、Bearerトークン、セッションID、OTKEY、FCMトークンをログやIssueへ投稿しないでください。
+
+## 基本情報
+
+| 項目 | 値 |
+| --- | --- |
+| Base URL | `https://smob.sic.shibaura-it.ac.jp/smob/api/` |
+| データ形式 | JSON |
+| SUKOMBUのHTTPクライアント | Retrofit / OkHttp |
+| 認証 | Bearerトークン |
+
+`POST /login`以外のリクエストでは、保存済みトークンが存在する場合に次のヘッダーを付与します。
+
+```http
+Authorization: Bearer <token>
+```
+
+SUKOMBUではHTTP 401をセッション失効として扱い、保存済み認証トークンを削除します。400番台はクライアントエラー、500番台はサーバーエラーとして処理します。
+
+## エンドポイント一覧
+
+| Method | Path | SUKOMBU | 用途 |
+| --- | --- | --- | --- |
+| POST | `/login` | 実装済み | ログインとBearerトークン取得 |
+| POST | `/reg_fcm` | 実装済み | FCMトークン登録 |
+| 未確定 | `/unreg_fcm` | 未実装 | FCMトークン登録解除 |
+| POST | `/sessionid` | 定義済み | ScombZセッションID送信 |
+| GET | `/otkey` | 実装済み | Web画面用OTKEY取得 |
+| GET | `/timetable/{yearMonth}` | 実装済み | 時間割取得 |
+| POST | `/timetable/{yearMonth}` | 実装済み | 授業メモ・色などの更新 |
+| GET | `/home/{yearMonth}` | 定義済み | ホーム情報取得 |
+| GET | `/task/{yearMonth}` | 実装済み | 課題・テスト・アンケート取得 |
+| GET | `/news` | 実装済み | お知らせ取得 |
+| POST | `/attend` | 未実装 | 出席登録 |
+| 未確定 | `/attend/{suffix}` | 未実装 | 登下校・打刻履歴取得 |
+
+`yearMonth`は年度と学期を表す6桁の値です。SUKOMBUでは前期を`YYYY01`、後期を`YYYY02`として扱います。
+
+`/unreg_fcm`と`/attend/{suffix}`は、HTTPメソッド、パス末尾、完全なリクエスト形式が未確定です。
+
+## POST `/login`
+
+### Request
+
+```json
+{
+  "user": "USER_ID",
+  "pass": "password"
+}
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `user` | string | yes | 学籍番号・ユーザーID |
+| `pass` | string | yes | パスワード |
+
+### Response
+
+```json
+{
+  "status": "OK",
+  "user_type": "student",
+  "gakubu": "...",
+  "gakka": "...",
+  "token": "...",
+  "terms": [
+    {
+      "year": 2026,
+      "start": ["...", "..."]
+    }
+  ]
+}
+```
+
+| Field | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `status` | string | no | 成否。SUKOMBUは`OK`を成功として扱う |
+| `user_type` | string | yes | ユーザー種別 |
+| `gakubu` | string | yes | 学部情報 |
+| `gakka` | string | yes | 学科情報 |
+| `token` | string | yes | Bearerトークン |
+| `terms` | array | yes | 学期情報 |
+| `terms[].year` | integer | no | 年度 |
+| `terms[].start` | string[] | no | 学期開始情報。各要素の意味は未確定 |
+
+## POST `/reg_fcm`
+
+### Request
+
+```json
+{
+  "fcm_token": "firebase-registration-token"
+}
+```
+
+### Response
+
+```json
+{
+  "status": "OK"
+}
+```
+
+## `/unreg_fcm`
+
+FCMトークン登録解除用のエンドポイントです。
+
+```text
+https://smob.sic.shibaura-it.ac.jp/smob/api/unreg_fcm
+```
+
+正確なHTTPメソッドとRequest bodyは未確定です。`/reg_fcm`と同じ`fcm_token`を使用する可能性があります。
+
+## POST `/sessionid`
+
+### Request
+
+```json
+{
+  "sessionid": "session-id"
+}
+```
+
+### Response
+
+```json
+{
+  "status": "OK"
+}
+```
+
+ScombZ WebセッションのIDをAPIへ送信します。現行SUKOMBUではRetrofitメソッドのみ定義され、通常のRepository処理からは呼び出していません。
+
+## GET `/otkey`
+
+### Response
+
+```json
+{
+  "status": "OK",
+  "otkey": "..."
+}
+```
+
+`otkey`は授業、課題、テスト、アンケートなどのWeb画面を開く際に使用します。
+
+## GET `/timetable/{yearMonth}`
+
+### Response
+
+```json
+[
+  {
+    "classId": "123456",
+    "name": "授業名",
+    "nameEnglish": "Class name",
+    "room": "教室",
+    "roomEnglish": "Room",
+    "teachers": "担当教員",
+    "teachersEnglish": "Teacher",
+    "period": 1,
+    "dayOfWeek": 1,
+    "syllabusUrl": "https://...",
+    "numberOfCredit": 2,
+    "note": "Base64 encoded value",
+    "customColor": "4294967295",
+    "otkey": "...",
+    "basyoCD": "...",
+    "quarter": "..."
+  }
+]
+```
+
+| Field | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `classId` | string | no | 授業ID |
+| `name` | string | no | 授業名 |
+| `nameEnglish` | string | yes | 授業名の英語表記 |
+| `room` | string | yes | 教室 |
+| `roomEnglish` | string | yes | 教室の英語表記 |
+| `teachers` | string | no | 担当教員 |
+| `teachersEnglish` | string | yes | 担当教員の英語表記 |
+| `period` | integer | no | 時限。APIは1始まり、SUKOMBU内部は0始まり |
+| `dayOfWeek` | integer | no | 曜日。APIは1始まり、SUKOMBU内部は0始まり |
+| `syllabusUrl` | string | yes | シラバスURL |
+| `numberOfCredit` | integer | yes | 単位数 |
+| `note` | string | yes | Base64文字列 |
+| `customColor` | string | yes | 符号なし整数を文字列化した色値 |
+| `otkey` | string | yes | Web画面用キー |
+| `basyoCD` | string | yes | 教室・場所コード |
+| `quarter` | string / integer | yes | クォーター情報。型は未確定 |
+
+一部の追加項目は、すべてのレスポンスで返るとは限りません。
+
+## POST `/timetable/{yearMonth}`
+
+授業のメモや色を更新します。Request bodyは配列です。
+
+```json
+[
+  {
+    "classId": "123456",
+    "customizedNumberOfCredit": 0,
+    "note": "memo",
+    "customColor": "4294967295"
+  }
+]
+```
+
+### Response
+
+```json
+{
+  "status": "OK"
+}
+```
+
+## GET `/home/{yearMonth}`
+
+時間割、課題、お知らせ、打刻情報をまとめて取得します。
+
+### Response
+
+```json
+{
+  "home_timetable": [],
+  "home_task": [],
+  "home_news": [],
+  "home_dakoku": {
+    "dakoku_time": "...",
+    "dakoku_campus": "..."
+  }
+}
+```
+
+| Field | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `home_timetable` | array | yes | 直近の時間割・授業情報 |
+| `home_task` | array | yes | 課題・テスト・アンケート |
+| `home_news` | array | yes | お知らせ |
+| `home_dakoku` | object | yes | 登下校・打刻情報 |
+| `home_dakoku.dakoku_time` | string | yes | 打刻時刻 |
+| `home_dakoku.dakoku_campus` | string | yes | 打刻キャンパス |
+
+空データ時の表現と各配列要素の完全なnull許容性は未確定です。
+
+## GET `/task/{yearMonth}`
+
+### Response
+
+```json
+[
+  {
+    "taskType": 0,
+    "id": "task-id",
+    "classId": "class-id",
+    "from": "授業名",
+    "title": "Base64 encoded title",
+    "done": 0,
+    "allowLate": 0,
+    "submitTimeFrom": "2026-07-01 00:00:00",
+    "submitTimeTo": "2026-07-31 23:59:59",
+    "publishTimeFrom": "2026-07-01 00:00:00",
+    "publishTimeTo": "2026-08-01 00:00:00",
+    "url": "...",
+    "relatedClassId": "...",
+    "otkey": "..."
+  }
+]
+```
+
+| Field | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `taskType` | integer | yes | `0`: 課題、`1`: テスト、`2`: アンケート |
+| `id` | string | yes | 課題等のID |
+| `classId` | string | yes | 授業ID |
+| `from` | string | yes | 授業名・発信元 |
+| `title` | string | yes | Base64文字列 |
+| `done` | integer | yes | `1`の場合は完了済み |
+| `allowLate` | integer / boolean | yes | 遅延提出可否。型は未確定 |
+| `submitTimeFrom` | string | yes | 提出開始日時 |
+| `submitTimeTo` | string | yes | 締切日時 |
+| `publishTimeFrom` | string | yes | 公開開始日時 |
+| `publishTimeTo` | string | yes | 公開終了日時 |
+| `url` | string | yes | 対象画面URL |
+| `relatedClassId` | string | yes | 関連授業ID |
+| `otkey` | string | yes | Web画面用キー |
+
+日時文字列は通常`yyyy-MM-dd HH:mm:ss`形式です。
+
+## GET `/news`
+
+### Response
+
+```json
+[
+  {
+    "newsId": "news-id",
+    "classId": "class-id",
+    "title": "Base64 encoded title",
+    "author": "Base64 encoded author",
+    "publishTime": "2026-07-23 12:00:00",
+    "tags": "LMS,重要",
+    "tagsEnglish": "LMS,Important",
+    "readTime": null,
+    "objectName1": null,
+    "objectName2": null,
+    "objectName3": null,
+    "fileName1": null,
+    "fileName2": null,
+    "fileName3": null,
+    "otkey": "..."
+  }
+]
+```
+
+| Field | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `newsId` | string | no | お知らせID |
+| `classId` | string | yes | LMSお知らせに関連する授業ID |
+| `title` | string | yes | Base64文字列 |
+| `author` | string | yes | 教授名または発信部署。Base64文字列 |
+| `publishTime` | string | yes | 公開日時 |
+| `tags` | string | yes | カンマ区切り。先頭要素をカテゴリとして使用 |
+| `tagsEnglish` | string | yes | タグの英語表記 |
+| `readTime` | string | yes | 空またはnullなら未読 |
+| `objectName1`～`objectName3` | string | yes | 添付オブジェクト名 |
+| `fileName1`～`fileName3` | string | yes | 添付ファイル名 |
+| `otkey` | string | yes | Web画面用キー |
+
+SUKOMBUの既読・未読切替はローカルRoomデータベース上で行います。現在のAPI定義には、既読状態を書き戻すエンドポイントはありません。
+
+`archived`と`starred`はローカル状態として扱われる可能性があります。
+
+## POST `/attend`
+
+出席登録を行います。
+
+### Request
+
+```json
+{
+  "classId": "class-id",
+  "seatId": "seat-id",
+  "roomId": "room-id"
+}
+```
+
+正確なキー表記、必須条件、追加項目、Response形式は未確定です。
+
+## `/attend/{suffix}`
+
+登下校・打刻履歴を取得します。パス末尾の値と完全なレスポンス構造は未確定です。
+
+関連する項目：
+
+```text
+dakoku_kbn
+dakoku_loc
+dakoku_time
+dakoku_campus
+```
+
+コード値の意味は未確定です。
+
+## 教室推定API
+
+ScombZ Mobile APIとは別に、次のBase URLを使用します。
+
+```text
+https://smobatnd.sic.shibaura-it.ac.jp/api
+```
+
+| Method | Path | 用途 |
+| --- | --- | --- |
+| GET | `/estimate_room/auth` | 教室推定用チャレンジ取得 |
+| POST | `/estimate_room/estimate` | ビーコン情報などから教室を推定 |
+
+関連するJSONキー：
+
+```text
+challenge
+challenge_key
+challenge_response
+gimbal_rssis
+seat_id
+scomb_auth_otkey
+estimated_rooms
+estimated_room_from_class
+```
+
+チャレンジ計算方式と配列要素の完全な構造は未確定です。
+
+## Base64処理
+
+SUKOMBUは次の値をBase64としてデコードし、失敗した場合は元の文字列をそのまま利用します。
+
+- 課題の`title`
+- お知らせの`title`
+- お知らせの`author`
+- 時間割の`note`
+
+デコード後はUTF-8文字列として扱います。
+
+## 関連するWeb URL
+
+```text
+https://mobile.scombz.shibaura-it.ac.jp/{otkey}/lms/course?idnumber={classId}
+https://mobile.scombz.shibaura-it.ac.jp/{otkey}/lms/course/report/submission?idnumber={classId}&reportId={id}
+https://mobile.scombz.shibaura-it.ac.jp/{otkey}/lms/course/examination/taketop?idnumber={classId}&examinationId={id}
+https://mobile.scombz.shibaura-it.ac.jp/{otkey}/lms/course/surveys/take?idnumber={classId}&surveyId={id}
+https://mobile.scombz.shibaura-it.ac.jp/news/{yearMonth}{newsId}?
+https://scombz.shibaura-it.ac.jp/lms/course?idnumber={classId}
+https://scombz.shibaura-it.ac.jp/lms/course/report/submission?idnumber={classId}&reportId={reportId}
+https://scombz.shibaura-it.ac.jp/lms/course/examination/taketop?idnumber={classId}&examinationId={examinationId}
+```
+
+これらはAPIエンドポイントではなく、認証済みWeb画面です。

--- a/app/src/main/java/com/atuy/scomb/MyApplication.kt
+++ b/app/src/main/java/com/atuy/scomb/MyApplication.kt
@@ -64,18 +64,17 @@ class MyApplication : Application(), Configuration.Provider {
             }
 
             FirebaseApp.initializeApp(this, options)
-            AppLogger.d("Spoofed Firebase Initialized successfully")
+            AppLogger.d("Spoofed Firebase initialized successfully")
 
             FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
                 if (!task.isSuccessful) {
-                    AppLogger.e("FCM Token generation failed: ${task.exception}")
+                    AppLogger.e("FCM token generation failed: ${task.exception}")
                     return@addOnCompleteListener
                 }
 
                 val token = task.result
-                AppLogger.d("🎉 Spoofed Token: $token")
+                AppLogger.d("FCM token generated")
 
-                // TODO: ここで取得したトークンをScombZのAPIサーバーへ送信・登録する処理を呼び出す
                 applicationScope.launch {
                     try {
                         scombzRepository.registerFcmToken(token)
@@ -88,6 +87,7 @@ class MyApplication : Application(), Configuration.Provider {
             AppLogger.e("Failed to initialize spoofed Firebase: ${e.message}")
         }
     }
+
     private fun setupBackgroundSync() {
         applicationScope.launch {
             val syncRequest = PeriodicWorkRequestBuilder<BackgroundSyncWorker>(

--- a/app/src/main/java/com/atuy/scomb/data/db/NewsItem.kt
+++ b/app/src/main/java/com/atuy/scomb/data/db/NewsItem.kt
@@ -3,6 +3,8 @@ package com.atuy.scomb.data.db
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+private const val UNKNOWN_NEWS_SOURCE = "掲載元不明"
+
 @Entity(tableName = "news_table")
 data class NewsItem(
     @PrimaryKey
@@ -17,3 +19,6 @@ data class NewsItem(
     val url: String,
     val otkey: String?
 )
+
+val NewsItem.hasSourceName: Boolean
+    get() = domain.isNotBlank() && domain != UNKNOWN_NEWS_SOURCE

--- a/app/src/main/java/com/atuy/scomb/data/repository/ScombzRepository.kt
+++ b/app/src/main/java/com/atuy/scomb/data/repository/ScombzRepository.kt
@@ -11,6 +11,7 @@ import com.atuy.scomb.data.db.Task
 import com.atuy.scomb.data.db.TaskDao
 import com.atuy.scomb.data.manager.AuthManager
 import com.atuy.scomb.data.network.ApiUpdateClassRequest
+import com.atuy.scomb.data.network.LoginRequest
 import com.atuy.scomb.data.network.ScombzApiService
 import com.atuy.scomb.util.ClientException
 import com.atuy.scomb.util.DateUtils
@@ -20,8 +21,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import retrofit2.Response
 import java.io.IOException
-import java.util.Calendar
-import java.util.Locale
 import javax.inject.Inject
 
 class ScombzRepository @Inject constructor(
@@ -32,7 +31,6 @@ class ScombzRepository @Inject constructor(
     private val authManager: AuthManager,
     @ApplicationContext private val context: Context
 ) {
-    // 共通のエラーハンドリングラッパー
     private suspend fun <T> executeWithAuthHandling(block: suspend () -> T): T {
         try {
             return block()
@@ -44,56 +42,50 @@ class ScombzRepository @Inject constructor(
                     authManager.clearAuthToken()
                     throw Exception(context.getString(R.string.error_session_expired), e)
                 }
-                is IOException -> {
-                    throw Exception(context.getString(R.string.error_network), e)
-                }
-                is ServerException -> {
-                    throw Exception(context.getString(R.string.error_server, e.code), e)
-                }
-                is ClientException -> {
-                    throw Exception(context.getString(R.string.error_client, e.code), e)
-                }
-                else -> {
-                    throw e
-                }
+                is IOException -> throw Exception(context.getString(R.string.error_network), e)
+                is ServerException -> throw Exception(context.getString(R.string.error_server, e.code), e)
+                is ClientException -> throw Exception(context.getString(R.string.error_client, e.code), e)
+                else -> throw e
             }
         }
     }
 
-    // APIレスポンスの検証ヘルパー
     private fun <T> validateResponse(response: Response<T>): T? {
-        if (response.isSuccessful) {
-            return response.body()
-        } else {
-            val code = response.code()
-            val errorBody = response.errorBody()?.string()
-            Log.e("ScombzRepository", "API Error: $code - $errorBody")
+        if (response.isSuccessful) return response.body()
 
-            when (code) {
-                401 -> throw SessionExpiredException()
-                in 400..499 -> throw ClientException(code, "Client Error: $code")
-                in 500..599 -> throw ServerException(code, "Server Error: $code")
-                else -> throw Exception("Unexpected error: $code")
-            }
+        val code = response.code()
+        val errorBody = response.errorBody()?.string()
+        Log.e("ScombzRepository", "API Error: $code - $errorBody")
+        when (code) {
+            401 -> throw SessionExpiredException()
+            in 400..499 -> throw ClientException(code, "Client Error: $code")
+            in 500..599 -> throw ServerException(code, "Server Error: $code")
+            else -> throw Exception("Unexpected error: $code")
         }
     }
 
     suspend fun login(userId: String, userPw: String): Result<Unit> {
         return try {
-            val response = apiService.login(com.atuy.scomb.data.network.LoginRequest(userId, userPw))
-
+            val response = apiService.login(LoginRequest(userId, userPw))
             if (response.isSuccessful) {
                 val body = response.body()
                 if (body != null && body.status == "OK" && body.token != null) {
                     authManager.saveAuthToken(body.token)
-                    authManager.saveUsername(userId) // ログイン成功時にユーザー名（学籍番号）を保存
+                    authManager.saveUsername(userId)
                     Result.success(Unit)
                 } else {
                     val statusMsg = body?.status ?: "Unknown status"
                     Result.failure(Exception(context.getString(R.string.error_login_failed, statusMsg)))
                 }
             } else {
-                Result.failure(Exception(context.getString(R.string.error_login_failed, "Code: ${response.code()}")))
+                Result.failure(
+                    Exception(
+                        context.getString(
+                            R.string.error_login_failed,
+                            "Code: ${response.code()}"
+                        )
+                    )
+                )
             }
         } catch (e: IOException) {
             Result.failure(Exception(context.getString(R.string.error_network), e))
@@ -103,9 +95,7 @@ class ScombzRepository @Inject constructor(
     }
 
     private suspend fun ensureAuthenticated() {
-        if (authManager.authTokenFlow.first() == null) {
-            throw SessionExpiredException()
-        }
+        if (authManager.authTokenFlow.first() == null) throw SessionExpiredException()
     }
 
     private suspend fun getOtkey(): Result<String> {
@@ -116,7 +106,6 @@ class ScombzRepository @Inject constructor(
                 return Result.success(body.otkey)
             }
         }
-
         if (response.code() == 401) throw SessionExpiredException()
         return Result.failure(Exception("Failed to get otkey: ${response.code()}"))
     }
@@ -129,13 +118,8 @@ class ScombzRepository @Inject constructor(
             }
 
             ensureAuthenticated()
-
-            val currentTerm = DateUtils.getCurrentScombTerm()
-            val yearMonth = currentTerm.yearApiTerm
-
-            val response = apiService.getTasks(yearMonth)
-            val apiTasks = validateResponse(response) ?: emptyList()
-
+            val yearMonth = DateUtils.getCurrentScombTerm().yearApiTerm
+            val apiTasks = validateResponse(apiService.getTasks(yearMonth)) ?: emptyList()
             val dbTasks = apiTasks.mapNotNull { it.toDbTask() }
 
             taskDao.clearApiTasks()
@@ -154,20 +138,16 @@ class ScombzRepository @Inject constructor(
 
             val existingCells = classCellDao.getCells(timetableTitle)
             val customLinksMap = existingCells.associate { it.classId to it.customLinksJson }
-
             ensureAuthenticated()
 
             val yearMonth = if (term == "1") "${year}01" else "${year}02"
-
-            val response = apiService.getTimetable(yearMonth)
-            val apiClassCells = validateResponse(response) ?: emptyList()
-
+            val apiClassCells = validateResponse(apiService.getTimetable(yearMonth)) ?: emptyList()
             val dbClassCells = apiClassCells.map {
                 it.toDbClassCell(
                     year,
                     term,
                     timetableTitle,
-                    existingUserNote = null, // APIの値を正とするため、ローカルキャッシュは無視
+                    existingUserNote = null,
                     existingCustomLinks = customLinksMap[it.id]
                 )
             }
@@ -178,40 +158,33 @@ class ScombzRepository @Inject constructor(
         }
     }
 
-    // メモと色などの設定を更新する汎用メソッド
     suspend fun updateClassInfo(classCell: ClassCell, note: String?, customColorInt: Int?) {
         executeWithAuthHandling {
             ensureAuthenticated()
-
-            val yearMonth = if (classCell.term == "1") "${classCell.year}01" else "${classCell.year}02"
-
-
+            val yearMonth = if (classCell.term == "1") {
+                "${classCell.year}01"
+            } else {
+                "${classCell.year}02"
+            }
             val colorString = if (customColorInt == null || customColorInt == 0) {
                 null
             } else {
                 Integer.toUnsignedString(customColorInt)
             }
-
             val request = ApiUpdateClassRequest(
                 classId = classCell.classId,
                 note = note,
                 customColor = colorString,
                 customizedNumberOfCredit = 0
             )
-
-            val response = apiService.updateClass(yearMonth, listOf(request))
-            val result = validateResponse(response)
-
-            if (result?.status == "OK") {
-                // 成功したらローカルDBも更新
-                val updatedCell = classCell.copy(
-                    note = note,
-                    customColorInt = customColorInt
-                )
-                classCellDao.insertClassCell(updatedCell)
-            } else {
+            val result = validateResponse(apiService.updateClass(yearMonth, listOf(request)))
+            if (result?.status != "OK") {
                 throw Exception("Failed to update class info: Status not OK")
             }
+
+            classCellDao.insertClassCell(
+                classCell.copy(note = note, customColorInt = customColorInt)
+            )
         }
     }
 
@@ -224,12 +197,8 @@ class ScombzRepository @Inject constructor(
 
             ensureAuthenticated()
             val currentTerm = DateUtils.getCurrentScombTerm()
-
-            val response = apiService.getNews()
-            val apiNews = validateResponse(response) ?: emptyList()
-
+            val apiNews = validateResponse(apiService.getNews()) ?: emptyList()
             val existingNewsMap = newsItemDao.getAllNews().associate { it.newsId to it.unread }
-
             val dbNews = apiNews.map { apiItem ->
                 val newItem = apiItem.toDbNewsItem(currentTerm.yearApiTerm)
                 if (existingNewsMap[newItem.newsId] == false) {
@@ -246,8 +215,15 @@ class ScombzRepository @Inject constructor(
     }
 
     suspend fun markAsRead(newsItem: NewsItem) {
+        setNewsUnread(listOf(newsItem), unread = false)
+    }
+
+    suspend fun setNewsUnread(newsItems: Collection<NewsItem>, unread: Boolean) {
+        if (newsItems.isEmpty()) return
         executeWithAuthHandling {
-            newsItemDao.insertOrUpdateNewsItem(newsItem.copy(unread = false))
+            newsItems.forEach { item ->
+                newsItemDao.insertOrUpdateNewsItem(item.copy(unread = unread))
+            }
         }
     }
 
@@ -256,7 +232,9 @@ class ScombzRepository @Inject constructor(
             ensureAuthenticated()
             val otkeyResult = getOtkey()
             val otkey = otkeyResult.getOrNull() ?: run {
-                if (otkeyResult.exceptionOrNull() is SessionExpiredException) throw SessionExpiredException()
+                if (otkeyResult.exceptionOrNull() is SessionExpiredException) {
+                    throw SessionExpiredException()
+                }
                 throw Exception(context.getString(R.string.error_otkey_failed))
             }
 
@@ -270,34 +248,27 @@ class ScombzRepository @Inject constructor(
     }
 
     suspend fun getClassUrl(classId: String): String {
-
         return executeWithAuthHandling {
             ensureAuthenticated()
             val otkeyResult = getOtkey()
             val otkey = otkeyResult.getOrNull() ?: run {
-                if (otkeyResult.exceptionOrNull() is SessionExpiredException) throw SessionExpiredException()
+                if (otkeyResult.exceptionOrNull() is SessionExpiredException) {
+                    throw SessionExpiredException()
+                }
                 throw Exception(context.getString(R.string.error_otkey_failed))
             }
-
             "https://mobile.scombz.shibaura-it.ac.jp/$otkey/lms/course?idnumber=$classId"
         }
     }
 
     suspend fun registerFcmToken(token: String) {
         executeWithAuthHandling {
-            // FCM登録は認証が必要かどうか確認が必要ですが、おそらく必要でしょう。
-            // しかし、ログイン前でも登録できる場合があるかもしれません。
-            // ここでは他のメソッド同様 ensureAuthenticated() を呼んでおきます。
             ensureAuthenticated()
-
-            val requestBody = mapOf("fcm_token" to token)
-            val response = apiService.registerFcm(requestBody)
-
-            val result = validateResponse(response)
-
+            val result = validateResponse(
+                apiService.registerFcm(mapOf("fcm_token" to token))
+            )
             if (result?.status != "OK") {
                 Log.e("ScombzRepository", "Failed to register FCM token: Status not OK")
-                // 必要であれば例外を投げたり、ユーザーに通知したりする
             } else {
                 Log.d("ScombzRepository", "FCM token registered successfully")
             }

--- a/app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt
+++ b/app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt
@@ -34,8 +34,7 @@ class ScombMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        AppLogger.d("Refreshed token: $token")
-        // トークンが更新された場合も、サーバーへ再送信が必要です
+        AppLogger.d("FCM token refreshed")
         serviceScope.launch {
             try {
                 scombzRepository.registerFcmToken(token)
@@ -47,10 +46,6 @@ class ScombMessagingService : FirebaseMessagingService() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // 必要ならScopeをキャンセルするが、Serviceが死ぬ時はプロセスごと死ぬことが多いので
-        // 厳密なキャンセルは必須ではないかもしれないが、マナーとして Job.cancel() ぐらいは想定できる
-        // ここでは簡単なフィールド初期化で済ませているため、onDestroyで明示的にキャンセルはしていないが、
-        // SupervisorJobを使っているので問題ない範囲。
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
@@ -66,8 +61,7 @@ class ScombMessagingService : FirebaseMessagingService() {
         val body = data["body"] ?: remoteMessage.notification?.body ?: "新しいお知らせがあります"
 
         if (newsUrl.isNullOrBlank()) {
-            AppLogger.d("Message data payload: ${remoteMessage.data}")
-            remoteMessage.notification?.let { AppLogger.d("Message Notification Body: ${it.body}") }
+            AppLogger.d("Message received without a news URL")
             return
         }
 

--- a/app/src/main/java/com/atuy/scomb/ui/features/NewsScreen.kt
+++ b/app/src/main/java/com/atuy/scomb/ui/features/NewsScreen.kt
@@ -7,8 +7,9 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,46 +27,34 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.atuy.scomb.data.db.NewsItem
-import com.atuy.scomb.ui.viewmodel.NewsFilter
+import com.atuy.scomb.data.db.hasSourceName
 import com.atuy.scomb.ui.viewmodel.NewsUiState
 import com.atuy.scomb.ui.viewmodel.NewsViewModel
 
@@ -97,8 +86,17 @@ fun NewsScreen(
                     FilterBar(
                         filter = state.filter,
                         categories = state.allCategories,
-                        authors = state.allAuthors,
+                        searchError = state.searchError,
                         onFilterChanged = viewModel::updateFilter
+                    )
+                }
+
+                AnimatedVisibility(visible = state.isSelectionMode) {
+                    NewsSelectionBar(
+                        state = state,
+                        onClearSelection = viewModel::clearSelection,
+                        onToggleSelectAll = viewModel::toggleSelectAllFiltered,
+                        onToggleReadState = viewModel::toggleSelectedReadState
                     )
                 }
 
@@ -109,10 +107,13 @@ fun NewsScreen(
                 ) {
                     NewsList(
                         newsItems = state.filteredNews,
-                        onItemClick = { newsItem ->
+                        isSelectionMode = state.isSelectionMode,
+                        selectedNewsIds = state.selectedNewsIds,
+                        onItemOpen = { newsItem ->
                             viewModel.markAsRead(newsItem)
                             context.openNewsUrl(newsItem.url)
-                        }
+                        },
+                        onSelectionToggle = viewModel::toggleNewsSelection
                     )
                 }
             }
@@ -134,179 +135,56 @@ private fun Context.openNewsUrl(url: String) {
 }
 
 @Composable
-fun FilterBar(
-    filter: NewsFilter,
-    categories: List<String>,
-    authors: List<String>,
-    onFilterChanged: (NewsFilter) -> Unit
+private fun NewsSelectionBar(
+    state: NewsUiState.Success,
+    onClearSelection: () -> Unit,
+    onToggleSelectAll: () -> Unit,
+    onToggleReadState: () -> Unit
 ) {
-    var searchQuery by remember(filter.searchQuery) {
-        mutableStateOf(filter.searchQuery)
-    }
-    val focusManager = LocalFocusManager.current
+    val visibleIds = state.filteredNews.map(NewsItem::newsId).toSet()
+    val allVisibleSelected = visibleIds.isNotEmpty() &&
+        visibleIds.all { it in state.selectedNewsIds }
 
-    Column(
-        modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .background(MaterialTheme.colorScheme.surface)
-    ) {
-        OutlinedTextField(
-            value = searchQuery,
-            onValueChange = { searchQuery = it },
-            placeholder = { Text("タイトルを検索") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            shape = RoundedCornerShape(12.dp),
-            leadingIcon = {
-                Icon(Icons.Default.Search, contentDescription = null)
-            },
-            trailingIcon = if (searchQuery.isNotEmpty()) {
-                {
-                    IconButton(
-                        onClick = {
-                            searchQuery = ""
-                            onFilterChanged(filter.copy(searchQuery = ""))
-                        }
-                    ) {
-                        Icon(Icons.Default.Close, contentDescription = "クリア")
-                    }
-                }
-            } else {
-                null
-            },
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    onFilterChanged(filter.copy(searchQuery = searchQuery))
-                    focusManager.clearFocus()
-                }
-            )
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
+    Surface(tonalElevation = 1.dp) {
         Row(
-            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = 8.dp, vertical = 2.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            FilterChip(
-                selected = filter.unreadOnly,
-                onClick = {
-                    onFilterChanged(filter.copy(unreadOnly = !filter.unreadOnly))
-                },
-                label = { Text("未読のみ") }
+            Text(
+                text = "${state.selectedNewsIds.size}件選択",
+                modifier = Modifier.padding(horizontal = 8.dp),
+                style = MaterialTheme.typography.labelLarge
             )
-
-            MultiSelectFilterChip(
-                label = "カテゴリ",
-                dialogTitle = "カテゴリを選択",
-                options = categories,
-                selectedOptions = filter.selectedCategories,
-                onSelectionChanged = {
-                    onFilterChanged(filter.copy(selectedCategories = it))
-                }
-            )
-
-            MultiSelectFilterChip(
-                label = "教授",
-                dialogTitle = "教授名を選択",
-                options = authors,
-                selectedOptions = filter.selectedAuthors,
-                onSelectionChanged = {
-                    onFilterChanged(filter.copy(selectedAuthors = it))
-                }
-            )
-        }
-    }
-}
-
-@Composable
-fun MultiSelectFilterChip(
-    label: String,
-    dialogTitle: String,
-    options: List<String>,
-    selectedOptions: Set<String>,
-    onSelectionChanged: (Set<String>) -> Unit
-) {
-    var showDialog by remember { mutableStateOf(false) }
-
-    val chipLabel = if (selectedOptions.isEmpty()) {
-        label
-    } else {
-        "$label (${selectedOptions.size})"
-    }
-
-    AssistChip(
-        onClick = { showDialog = true },
-        label = { Text(chipLabel) },
-        trailingIcon = {
-            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
-        },
-        enabled = options.isNotEmpty()
-    )
-
-    if (showDialog) {
-        var temporarySelection by remember(selectedOptions) {
-            mutableStateOf(selectedOptions)
-        }
-
-        AlertDialog(
-            onDismissRequest = { showDialog = false },
-            title = { Text(dialogTitle) },
-            text = {
-                LazyColumn {
-                    items(options, key = { it }) { option ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    temporarySelection = temporarySelection.toggle(option)
-                                }
-                                .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Checkbox(
-                                checked = option in temporarySelection,
-                                onCheckedChange = {
-                                    temporarySelection = temporarySelection.toggle(option)
-                                }
-                            )
-                            Text(
-                                text = option,
-                                modifier = Modifier.padding(start = 8.dp)
-                            )
-                        }
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        onSelectionChanged(temporarySelection)
-                        showDialog = false
-                    }
-                ) {
-                    Text("OK")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDialog = false }) {
-                    Text("キャンセル")
-                }
+            TextButton(
+                onClick = onToggleSelectAll,
+                enabled = state.filteredNews.isNotEmpty()
+            ) {
+                Text(if (allVisibleSelected) "全て解除" else "全て選択")
             }
-        )
+            TextButton(
+                onClick = onToggleReadState,
+                enabled = state.selectedNewsIds.isNotEmpty()
+            ) {
+                Text(if (state.selectedNewsAreAllRead) "未読" else "既読")
+            }
+            IconButton(onClick = onClearSelection) {
+                Icon(Icons.Default.Close, contentDescription = "選択を終了")
+            }
+        }
     }
-}
-
-private fun Set<String>.toggle(value: String): Set<String> {
-    return if (value in this) this - value else this + value
 }
 
 @Composable
 fun NewsList(
     newsItems: List<NewsItem>,
-    onItemClick: (NewsItem) -> Unit
+    isSelectionMode: Boolean,
+    selectedNewsIds: Set<String>,
+    onItemOpen: (NewsItem) -> Unit,
+    onSelectionToggle: (String) -> Unit
 ) {
     if (newsItems.isEmpty()) {
         Box(
@@ -332,41 +210,66 @@ fun NewsList(
         ) { news ->
             NewsCard(
                 newsItem = news,
-                onClick = { onItemClick(news) }
+                isSelectionMode = isSelectionMode,
+                isSelected = news.newsId in selectedNewsIds,
+                onClick = {
+                    if (isSelectionMode) {
+                        onSelectionToggle(news.newsId)
+                    } else {
+                        onItemOpen(news)
+                    }
+                },
+                onLongClick = { onSelectionToggle(news.newsId) },
+                onSelectionToggle = { onSelectionToggle(news.newsId) }
             )
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NewsCard(
     newsItem: NewsItem,
-    onClick: () -> Unit
+    isSelectionMode: Boolean,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onSelectionToggle: () -> Unit
 ) {
-    val alpha = if (newsItem.unread) 1.0f else 0.6f
-    val containerColor = if (newsItem.unread) {
-        MaterialTheme.colorScheme.surfaceContainer
-    } else {
-        MaterialTheme.colorScheme.surfaceContainerLow
+    val alpha = if (newsItem.unread || isSelected) 1.0f else 0.6f
+    val containerColor = when {
+        isSelected -> MaterialTheme.colorScheme.primaryContainer
+        newsItem.unread -> MaterialTheme.colorScheme.surfaceContainer
+        else -> MaterialTheme.colorScheme.surfaceContainerLow
     }
 
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .alpha(alpha)
-            .clickable(onClick = onClick),
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            ),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = containerColor),
         elevation = CardDefaults.cardElevation(
-            defaultElevation = if (newsItem.unread) 2.dp else 0.dp
+            defaultElevation = if (newsItem.unread || isSelected) 2.dp else 0.dp
         )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
                 verticalAlignment = Alignment.Top,
-                horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth()
             ) {
+                if (isSelectionMode) {
+                    Checkbox(
+                        checked = isSelected,
+                        onCheckedChange = { onSelectionToggle() },
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                }
+
                 Text(
                     text = newsItem.title,
                     style = MaterialTheme.typography.titleMedium,
@@ -417,11 +320,15 @@ fun NewsCard(
                 Spacer(modifier = Modifier.weight(1f))
 
                 Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        text = newsItem.domain,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    if (newsItem.hasSourceName) {
+                        Text(
+                            text = "発信元: ${newsItem.domain}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                     Text(
                         text = newsItem.publishTime,
                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/atuy/scomb/ui/features/NewsSearchComponents.kt
+++ b/app/src/main/java/com/atuy/scomb/ui/features/NewsSearchComponents.kt
@@ -1,0 +1,386 @@
+package com.atuy.scomb.ui.features
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.atuy.scomb.ui.viewmodel.AdvancedNewsSearchInput
+import com.atuy.scomb.ui.viewmodel.NewsFilter
+
+@Composable
+fun FilterBar(
+    filter: NewsFilter,
+    categories: List<String>,
+    searchError: String?,
+    onFilterChanged: (NewsFilter) -> Unit
+) {
+    var showAdvancedSearch by remember { mutableStateOf(false) }
+
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            NewsSearchField(
+                value = filter.searchQuery,
+                placeholder = "タイトル・発信元を検索",
+                onValueChange = {
+                    onFilterChanged(filter.copy(searchQuery = it))
+                },
+                modifier = Modifier.weight(1f),
+                isError = searchError != null
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            IconButton(onClick = { showAdvancedSearch = true }) {
+                Icon(Icons.Default.Tune, contentDescription = "詳細検索")
+            }
+        }
+
+        if (searchError != null) {
+            Text(
+                text = searchError,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 12.dp, top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilterChip(
+                selected = filter.unreadOnly,
+                onClick = {
+                    onFilterChanged(filter.copy(unreadOnly = !filter.unreadOnly))
+                },
+                label = { Text("未読のみ") }
+            )
+
+            MultiSelectFilterChip(
+                label = "カテゴリ",
+                dialogTitle = "カテゴリを選択",
+                options = categories,
+                selectedOptions = filter.selectedCategories,
+                onSelectionChanged = {
+                    onFilterChanged(filter.copy(selectedCategories = it))
+                }
+            )
+        }
+    }
+
+    if (showAdvancedSearch) {
+        AdvancedSearchDialog(
+            onDismiss = { showAdvancedSearch = false },
+            onApply = { input ->
+                onFilterChanged(filter.copy(searchQuery = input.toQuery()))
+                showAdvancedSearch = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun NewsSearchField(
+    value: String,
+    placeholder: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false
+) {
+    val focusManager = LocalFocusManager.current
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = { Text(placeholder) },
+        modifier = modifier,
+        singleLine = true,
+        isError = isError,
+        shape = RoundedCornerShape(12.dp),
+        leadingIcon = {
+            Icon(Icons.Default.Search, contentDescription = null)
+        },
+        trailingIcon = if (value.isNotEmpty()) {
+            {
+                IconButton(onClick = { onValueChange("") }) {
+                    Icon(Icons.Default.Close, contentDescription = "検索をクリア")
+                }
+            }
+        } else {
+            null
+        },
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(
+            onSearch = { focusManager.clearFocus() }
+        )
+    )
+}
+
+@Composable
+private fun AdvancedSearchDialog(
+    onDismiss: () -> Unit,
+    onApply: (AdvancedNewsSearchInput) -> Unit
+) {
+    var allWords by remember { mutableStateOf("") }
+    var exactPhrase by remember { mutableStateOf("") }
+    var anyWords by remember { mutableStateOf("") }
+    var excludedWords by remember { mutableStateOf("") }
+    var titlePhrase by remember { mutableStateOf("") }
+    var authorPhrase by remember { mutableStateOf("") }
+    var since by remember { mutableStateOf("") }
+    var until by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("詳細検索") },
+        text = {
+            LazyColumn(
+                modifier = Modifier.heightIn(max = 560.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item {
+                    Text(
+                        "入力内容から検索式を生成します。未入力の項目は無視されます。",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = allWords,
+                        onValueChange = { allWords = it },
+                        label = "すべて含む語",
+                        placeholder = "空白区切り"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = exactPhrase,
+                        onValueChange = { exactPhrase = it },
+                        label = "完全一致フレーズ"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = anyWords,
+                        onValueChange = { anyWords = it },
+                        label = "いずれかを含む語",
+                        placeholder = "空白区切り"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = excludedWords,
+                        onValueChange = { excludedWords = it },
+                        label = "含まない語",
+                        placeholder = "空白区切り"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = titlePhrase,
+                        onValueChange = { titlePhrase = it },
+                        label = "タイトルに含むフレーズ"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = authorPhrase,
+                        onValueChange = { authorPhrase = it },
+                        label = "発信元に含むフレーズ"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = since,
+                        onValueChange = { since = it },
+                        label = "開始日",
+                        placeholder = "YYYY-MM-DD"
+                    )
+                }
+                item {
+                    AdvancedSearchField(
+                        value = until,
+                        onValueChange = { until = it },
+                        label = "終了日",
+                        placeholder = "YYYY-MM-DD"
+                    )
+                }
+                item {
+                    Text(
+                        "検索バーへ直接入力する場合は \"フレーズ\"、-除外、OR、since:、until:、title:(...)、author:(...) を使用できます。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onApply(
+                        AdvancedNewsSearchInput(
+                            allWords = allWords,
+                            exactPhrase = exactPhrase,
+                            anyWords = anyWords,
+                            excludedWords = excludedWords,
+                            titlePhrase = titlePhrase,
+                            authorPhrase = authorPhrase,
+                            since = since,
+                            until = until
+                        )
+                    )
+                }
+            ) {
+                Text("検索式を適用")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("キャンセル")
+            }
+        }
+    )
+}
+
+@Composable
+private fun AdvancedSearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    placeholder: String? = null
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        placeholder = if (placeholder == null) null else {
+            { Text(placeholder) }
+        },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true
+    )
+}
+
+@Composable
+fun MultiSelectFilterChip(
+    label: String,
+    dialogTitle: String,
+    options: List<String>,
+    selectedOptions: Set<String>,
+    onSelectionChanged: (Set<String>) -> Unit
+) {
+    var showDialog by remember { mutableStateOf(false) }
+
+    val chipLabel = if (selectedOptions.isEmpty()) {
+        label
+    } else {
+        "$label (${selectedOptions.size})"
+    }
+
+    AssistChip(
+        onClick = { showDialog = true },
+        label = { Text(chipLabel) },
+        trailingIcon = {
+            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+        },
+        enabled = options.isNotEmpty()
+    )
+
+    if (showDialog) {
+        var temporarySelection by remember(selectedOptions) {
+            mutableStateOf(selectedOptions)
+        }
+
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text(dialogTitle) },
+            text = {
+                LazyColumn {
+                    items(options, key = { it }) { option ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    temporarySelection = temporarySelection.toggle(option)
+                                }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = option in temporarySelection,
+                                onCheckedChange = {
+                                    temporarySelection = temporarySelection.toggle(option)
+                                }
+                            )
+                            Text(
+                                text = option,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onSelectionChanged(temporarySelection)
+                        showDialog = false
+                    }
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+}
+
+private fun Set<String>.toggle(value: String): Set<String> {
+    return if (value in this) this - value else this + value
+}

--- a/app/src/main/java/com/atuy/scomb/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/atuy/scomb/ui/viewmodel/HomeViewModel.kt
@@ -63,14 +63,17 @@ class HomeViewModel @Inject constructor(
         LinkItem("シラバス", "https://syllabus.sic.shibaura-it.ac.jp/"),
         LinkItem("時間割検索", "https://timetable.sic.shibaura-it.ac.jp/"),
         LinkItem("学年歴", "https://www.shibaura-it.ac.jp/campus_life/school_calendar"),
-        LinkItem("S*gsot", "https://sgsot.sic.shibaura-it.ac.jp", appendUsername = true),
+        LinkItem(
+            "CITRUS",
+            "https://sitrus.sic.shibaura-it.ac.jp/SITRUS/login/index.html?N=",
+            appendUsername = true
+        ),
         LinkItem("スーパー英語", "https://supereigo2.sic.shibaura-it.ac.jp/sso/"),
         LinkItem("図書館", "https://lib.shibaura-it.ac.jp")
     )
 
     private val _openUrlEvent = Channel<String>(Channel.BUFFERED)
     val openUrlEvent = _openUrlEvent.receiveAsFlow()
-
 
     init {
         loadHomeData(forceRefresh = false)

--- a/app/src/main/java/com/atuy/scomb/ui/viewmodel/NewsSearchQuery.kt
+++ b/app/src/main/java/com/atuy/scomb/ui/viewmodel/NewsSearchQuery.kt
@@ -1,0 +1,325 @@
+package com.atuy.scomb.ui.viewmodel
+
+import com.atuy.scomb.data.db.NewsItem
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+
+data class AdvancedNewsSearchInput(
+    val allWords: String = "",
+    val exactPhrase: String = "",
+    val anyWords: String = "",
+    val excludedWords: String = "",
+    val titlePhrase: String = "",
+    val authorPhrase: String = "",
+    val since: String = "",
+    val until: String = ""
+) {
+    fun toQuery(): String {
+        val clauses = buildList {
+            addAll(allWords.toTerms())
+            exactPhrase.trim().takeIf(String::isNotEmpty)?.let { add(it.asQuotedPhrase()) }
+
+            anyWords.toTerms()
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString(" OR ")
+                ?.let { add("($it)") }
+
+            addAll(excludedWords.toTerms().map { "-$it" })
+
+            titlePhrase.trim().takeIf(String::isNotEmpty)?.let {
+                add("title:(${it.asQuotedPhrase()})")
+            }
+            authorPhrase.trim().takeIf(String::isNotEmpty)?.let {
+                add("author:(${it.asQuotedPhrase()})")
+            }
+            since.trim().takeIf(String::isNotEmpty)?.let { add("since:$it") }
+            until.trim().takeIf(String::isNotEmpty)?.let { add("until:$it") }
+        }
+        return clauses.joinToString(" ")
+    }
+}
+
+private fun String.toTerms(): List<String> =
+    trim().split(Regex("\\s+")).filter(String::isNotEmpty).map(String::asSearchTerm)
+
+private fun String.asSearchTerm(): String =
+    if (any { it.isWhitespace() || it in "()\"" } || this == "OR") {
+        asQuotedPhrase()
+    } else {
+        this
+    }
+
+private fun String.asQuotedPhrase(): String =
+    "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
+
+class NewsSearchMatcher private constructor(
+    private val expression: SearchExpression?,
+    val error: String?
+) {
+    fun matches(item: NewsItem): Boolean = expression?.matches(item, SearchField.ANY) ?: true
+
+    companion object {
+        fun parse(query: String): NewsSearchMatcher {
+            if (query.isBlank()) return NewsSearchMatcher(expression = null, error = null)
+
+            return try {
+                val parser = Parser(Lexer(query).tokenize())
+                NewsSearchMatcher(expression = parser.parse(), error = null)
+            } catch (e: SearchSyntaxException) {
+                NewsSearchMatcher(expression = null, error = e.message)
+            }
+        }
+    }
+}
+
+private enum class SearchField {
+    ANY,
+    TITLE,
+    AUTHOR
+}
+
+private sealed interface SearchExpression {
+    fun matches(item: NewsItem, field: SearchField): Boolean
+}
+
+private data class TermExpression(val value: String) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean {
+        return when (field) {
+            SearchField.ANY -> item.title.contains(value, ignoreCase = true) ||
+                item.domain.contains(value, ignoreCase = true)
+            SearchField.TITLE -> item.title.contains(value, ignoreCase = true)
+            SearchField.AUTHOR -> item.domain.contains(value, ignoreCase = true)
+        }
+    }
+}
+
+private data class AndExpression(val expressions: List<SearchExpression>) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean =
+        expressions.all { it.matches(item, field) }
+}
+
+private data class OrExpression(val expressions: List<SearchExpression>) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean =
+        expressions.any { it.matches(item, field) }
+}
+
+private data class NotExpression(val expression: SearchExpression) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean =
+        !expression.matches(item, field)
+}
+
+private data class FieldExpression(
+    val field: SearchField,
+    val expression: SearchExpression
+) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean =
+        expression.matches(item, this.field)
+}
+
+private data class SinceExpression(val date: LocalDate) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean =
+        item.publishDate()?.let { !it.isBefore(date) } ?: false
+}
+
+private data class UntilExpression(val date: LocalDate) : SearchExpression {
+    override fun matches(item: NewsItem, field: SearchField): Boolean =
+        item.publishDate()?.let { !it.isAfter(date) } ?: false
+}
+
+private fun NewsItem.publishDate(): LocalDate? {
+    val value = publishTime.trim()
+    if (value.length < 10) return null
+    return runCatching { LocalDate.parse(value.substring(0, 10)) }.getOrNull()
+}
+
+private sealed interface SearchToken {
+    data class Word(val value: String) : SearchToken
+    data class Phrase(val value: String) : SearchToken
+    data class Since(val value: String) : SearchToken
+    data class Until(val value: String) : SearchToken
+    data object FieldTitle : SearchToken
+    data object FieldAuthor : SearchToken
+    data object Or : SearchToken
+    data object Not : SearchToken
+    data object LeftParen : SearchToken
+    data object RightParen : SearchToken
+    data object End : SearchToken
+}
+
+private class Lexer(private val source: String) {
+    private var index = 0
+
+    fun tokenize(): List<SearchToken> {
+        val tokens = mutableListOf<SearchToken>()
+        while (index < source.length) {
+            when {
+                source[index].isWhitespace() -> index++
+                source[index] == '(' -> {
+                    tokens += SearchToken.LeftParen
+                    index++
+                }
+                source[index] == ')' -> {
+                    tokens += SearchToken.RightParen
+                    index++
+                }
+                source[index] == '-' -> {
+                    tokens += SearchToken.Not
+                    index++
+                }
+                source[index] == '"' -> tokens += readPhrase()
+                else -> tokens += readWord()
+            }
+        }
+        tokens += SearchToken.End
+        return tokens
+    }
+
+    private fun readPhrase(): SearchToken.Phrase {
+        index++
+        val value = StringBuilder()
+        var escaped = false
+        while (index < source.length) {
+            val char = source[index++]
+            when {
+                escaped -> {
+                    value.append(char)
+                    escaped = false
+                }
+                char == '\\' -> escaped = true
+                char == '"' -> return SearchToken.Phrase(value.toString())
+                else -> value.append(char)
+            }
+        }
+        throw SearchSyntaxException("引用符が閉じられていません")
+    }
+
+    private fun readWord(): SearchToken {
+        val start = index
+        while (
+            index < source.length &&
+            !source[index].isWhitespace() &&
+            source[index] !in "()\""
+        ) {
+            index++
+        }
+        val word = source.substring(start, index)
+        if (word.isEmpty()) throw SearchSyntaxException("検索式を解析できません")
+
+        return when {
+            word == "OR" -> SearchToken.Or
+            word.equals("title:", ignoreCase = true) -> SearchToken.FieldTitle
+            word.equals("author:", ignoreCase = true) -> SearchToken.FieldAuthor
+            word.startsWith("title:", ignoreCase = true) ->
+                throw SearchSyntaxException("title: の検索範囲は title:(...) の形式で指定してください")
+            word.startsWith("author:", ignoreCase = true) ->
+                throw SearchSyntaxException("author: の検索範囲は author:(...) の形式で指定してください")
+            word.startsWith("since:", ignoreCase = true) ->
+                SearchToken.Since(word.substringAfter(':'))
+            word.startsWith("until:", ignoreCase = true) ->
+                SearchToken.Until(word.substringAfter(':'))
+            else -> SearchToken.Word(word)
+        }
+    }
+}
+
+private class Parser(private val tokens: List<SearchToken>) {
+    private var index = 0
+
+    fun parse(): SearchExpression {
+        val expression = parseOr()
+        if (peek() != SearchToken.End) {
+            throw SearchSyntaxException("検索式の末尾を解析できません")
+        }
+        return expression
+    }
+
+    private fun parseOr(): SearchExpression {
+        val expressions = mutableListOf(parseAnd())
+        while (peek() == SearchToken.Or) {
+            consume()
+            if (!startsExpression(peek())) {
+                throw SearchSyntaxException("OR の後に検索条件が必要です")
+            }
+            expressions += parseAnd()
+        }
+        return expressions.singleOrNull() ?: OrExpression(expressions)
+    }
+
+    private fun parseAnd(): SearchExpression {
+        val expressions = mutableListOf<SearchExpression>()
+        while (startsExpression(peek())) {
+            expressions += parseUnary()
+        }
+        if (expressions.isEmpty()) {
+            throw SearchSyntaxException("検索条件が必要です")
+        }
+        return expressions.singleOrNull() ?: AndExpression(expressions)
+    }
+
+    private fun parseUnary(): SearchExpression {
+        return when (val token = consume()) {
+            SearchToken.Not -> {
+                if (!startsExpression(peek())) {
+                    throw SearchSyntaxException("- の後に除外条件が必要です")
+                }
+                NotExpression(parseUnary())
+            }
+            SearchToken.LeftParen -> {
+                val expression = parseOr()
+                requireToken<SearchToken.RightParen>("括弧が閉じられていません")
+                expression
+            }
+            SearchToken.FieldTitle -> parseField(SearchField.TITLE, "title")
+            SearchToken.FieldAuthor -> parseField(SearchField.AUTHOR, "author")
+            is SearchToken.Since -> SinceExpression(parseDate(token.value, "since"))
+            is SearchToken.Until -> UntilExpression(parseDate(token.value, "until"))
+            is SearchToken.Word -> TermExpression(token.value)
+            is SearchToken.Phrase -> TermExpression(token.value)
+            else -> throw SearchSyntaxException("検索条件を解析できません")
+        }
+    }
+
+    private fun parseField(field: SearchField, name: String): SearchExpression {
+        if (consume() != SearchToken.LeftParen) {
+            throw SearchSyntaxException("$name: の検索範囲は $name:(...) の形式で指定してください")
+        }
+        val expression = parseOr()
+        requireToken<SearchToken.RightParen>("$name:(...) の括弧が閉じられていません")
+        return FieldExpression(field, expression)
+    }
+
+    private fun parseDate(value: String, operator: String): LocalDate {
+        if (value.isBlank()) {
+            throw SearchSyntaxException("$operator: の後に YYYY-MM-DD 形式の日付が必要です")
+        }
+        return try {
+            LocalDate.parse(value)
+        } catch (_: DateTimeParseException) {
+            throw SearchSyntaxException("$operator:$value は有効な YYYY-MM-DD 形式ではありません")
+        }
+    }
+
+    private inline fun <reified T : SearchToken> requireToken(message: String) {
+        if (consume() !is T) throw SearchSyntaxException(message)
+    }
+
+    private fun startsExpression(token: SearchToken): Boolean = when (token) {
+        SearchToken.Not,
+        SearchToken.LeftParen,
+        SearchToken.FieldTitle,
+        SearchToken.FieldAuthor,
+        is SearchToken.Since,
+        is SearchToken.Until,
+        is SearchToken.Word,
+        is SearchToken.Phrase -> true
+        SearchToken.Or,
+        SearchToken.RightParen,
+        SearchToken.End -> false
+    }
+
+    private fun peek(): SearchToken = tokens[index]
+
+    private fun consume(): SearchToken = tokens[index++]
+}
+
+private class SearchSyntaxException(message: String) : IllegalArgumentException(message)

--- a/app/src/main/java/com/atuy/scomb/ui/viewmodel/NewsViewModel.kt
+++ b/app/src/main/java/com/atuy/scomb/ui/viewmodel/NewsViewModel.kt
@@ -17,8 +17,7 @@ import javax.inject.Inject
 data class NewsFilter(
     val searchQuery: String = "",
     val unreadOnly: Boolean = false,
-    val selectedCategories: Set<String> = emptySet(),
-    val selectedAuthors: Set<String> = emptySet()
+    val selectedCategories: Set<String> = emptySet()
 )
 
 sealed interface NewsUiState {
@@ -27,9 +26,12 @@ sealed interface NewsUiState {
     data class Success(
         val filteredNews: List<NewsItem>,
         val allCategories: List<String>,
-        val allAuthors: List<String>,
         val filter: NewsFilter,
+        val searchError: String?,
         val isSearchActive: Boolean,
+        val isSelectionMode: Boolean = false,
+        val selectedNewsIds: Set<String> = emptySet(),
+        val selectedNewsAreAllRead: Boolean = false,
         val isRefreshing: Boolean = false
     ) : NewsUiState
 
@@ -81,7 +83,8 @@ class NewsViewModel @Inject constructor(
                 val previousSuccess = previousState as? NewsUiState.Success
                 _uiState.value = createSuccessState(
                     filter = previousSuccess?.filter ?: NewsFilter(),
-                    isSearchActive = previousSuccess?.isSearchActive ?: false
+                    isSearchActive = previousSuccess?.isSearchActive ?: false,
+                    selectedNewsIds = previousSuccess?.selectedNewsIds.orEmpty()
                 )
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
@@ -93,20 +96,62 @@ class NewsViewModel @Inject constructor(
     }
 
     fun markAsRead(newsItem: NewsItem) {
+        if (!newsItem.unread) return
+        updateNewsUnreadState(
+            newsIds = setOf(newsItem.newsId),
+            unread = false,
+            exitSelectionMode = false
+        )
+    }
+
+    fun toggleSelectedReadState() {
+        val currentState = _uiState.value as? NewsUiState.Success ?: return
+        val selectedItems = allNews.filter { it.newsId in currentState.selectedNewsIds }
+        if (selectedItems.isEmpty()) return
+
+        val shouldMarkUnread = selectedItems.all { !it.unread }
+        updateNewsUnreadState(
+            newsIds = currentState.selectedNewsIds,
+            unread = shouldMarkUnread,
+            exitSelectionMode = true
+        )
+    }
+
+    private fun updateNewsUnreadState(
+        newsIds: Set<String>,
+        unread: Boolean,
+        exitSelectionMode: Boolean
+    ) {
+        if (newsIds.isEmpty()) return
+
         viewModelScope.launch {
-            repository.markAsRead(newsItem)
-            allNews = allNews.map { item ->
-                if (item.newsId == newsItem.newsId) item.copy(unread = false) else item
+            val changedItems = allNews.filter { item ->
+                item.newsId in newsIds && item.unread != unread
             }
-            applyUiFilters()
+            repository.setNewsUnread(changedItems, unread)
+
+            allNews = allNews.map { item ->
+                if (item.newsId in newsIds) item.copy(unread = unread) else item
+            }
+
+            val currentState = _uiState.value as? NewsUiState.Success ?: return@launch
+            val selectedIds = if (exitSelectionMode) emptySet() else currentState.selectedNewsIds
+            _uiState.value = buildSuccessState(
+                currentState = currentState,
+                filter = currentState.filter,
+                selectedNewsIds = selectedIds,
+                isSelectionMode = !exitSelectionMode && selectedIds.isNotEmpty()
+            )
         }
     }
 
     fun updateFilter(newFilter: NewsFilter) {
         val currentState = _uiState.value as? NewsUiState.Success ?: return
-        _uiState.value = currentState.copy(
+        _uiState.value = buildSuccessState(
+            currentState = currentState,
             filter = newFilter,
-            filteredNews = applyFilters(allNews, newFilter)
+            selectedNewsIds = currentState.selectedNewsIds,
+            isSelectionMode = currentState.isSelectionMode
         )
     }
 
@@ -117,16 +162,48 @@ class NewsViewModel @Inject constructor(
         )
     }
 
-    private fun applyUiFilters() {
+    fun clearSelection() {
         val currentState = _uiState.value as? NewsUiState.Success ?: return
         _uiState.value = currentState.copy(
-            filteredNews = applyFilters(allNews, currentState.filter)
+            isSelectionMode = false,
+            selectedNewsIds = emptySet(),
+            selectedNewsAreAllRead = false
+        )
+    }
+
+    fun toggleNewsSelection(newsId: String) {
+        val currentState = _uiState.value as? NewsUiState.Success ?: return
+        val selectedIds = currentState.selectedNewsIds.toggle(newsId)
+        _uiState.value = currentState.copy(
+            isSelectionMode = selectedIds.isNotEmpty(),
+            selectedNewsIds = selectedIds,
+            selectedNewsAreAllRead = selectedIds.areAllRead()
+        )
+    }
+
+    fun toggleSelectAllFiltered() {
+        val currentState = _uiState.value as? NewsUiState.Success ?: return
+        val visibleIds = currentState.filteredNews.map(NewsItem::newsId).toSet()
+        if (visibleIds.isEmpty()) return
+
+        val allVisibleSelected = visibleIds.all { it in currentState.selectedNewsIds }
+        val selectedIds = if (allVisibleSelected) {
+            currentState.selectedNewsIds - visibleIds
+        } else {
+            currentState.selectedNewsIds + visibleIds
+        }
+
+        _uiState.value = currentState.copy(
+            isSelectionMode = selectedIds.isNotEmpty(),
+            selectedNewsIds = selectedIds,
+            selectedNewsAreAllRead = selectedIds.areAllRead()
         )
     }
 
     private fun createSuccessState(
         filter: NewsFilter,
-        isSearchActive: Boolean
+        isSearchActive: Boolean,
+        selectedNewsIds: Set<String>
     ): NewsUiState.Success {
         val categories = allNews
             .map(NewsItem::category)
@@ -134,45 +211,70 @@ class NewsViewModel @Inject constructor(
             .distinct()
             .sorted()
 
-        val authors = allNews
-            .map(NewsItem::domain)
-            .filter { it.isNotBlank() && it != UNKNOWN_AUTHOR }
-            .distinct()
-            .sorted()
-
         val normalizedFilter = filter.copy(
-            selectedCategories = filter.selectedCategories.intersect(categories.toSet()),
-            selectedAuthors = filter.selectedAuthors.intersect(authors.toSet())
+            selectedCategories = filter.selectedCategories.intersect(categories.toSet())
         )
+        val existingIds = allNews.map(NewsItem::newsId).toSet()
+        val normalizedSelectedIds = selectedNewsIds.intersect(existingIds)
+        val filtered = applyFilters(allNews, normalizedFilter)
 
         return NewsUiState.Success(
-            filteredNews = applyFilters(allNews, normalizedFilter),
+            filteredNews = filtered.items,
             allCategories = categories,
-            allAuthors = authors,
             filter = normalizedFilter,
+            searchError = filtered.error,
             isSearchActive = isSearchActive,
+            isSelectionMode = normalizedSelectedIds.isNotEmpty(),
+            selectedNewsIds = normalizedSelectedIds,
+            selectedNewsAreAllRead = normalizedSelectedIds.areAllRead(),
             isRefreshing = false
+        )
+    }
+
+    private fun buildSuccessState(
+        currentState: NewsUiState.Success,
+        filter: NewsFilter,
+        selectedNewsIds: Set<String>,
+        isSelectionMode: Boolean
+    ): NewsUiState.Success {
+        val filtered = applyFilters(allNews, filter)
+        return currentState.copy(
+            filteredNews = filtered.items,
+            filter = filter,
+            searchError = filtered.error,
+            isSelectionMode = isSelectionMode,
+            selectedNewsIds = selectedNewsIds,
+            selectedNewsAreAllRead = selectedNewsIds.areAllRead()
         )
     }
 
     private fun applyFilters(
         news: List<NewsItem>,
         filter: NewsFilter
-    ): List<NewsItem> {
-        return news.filter { item ->
-            val queryMatches = filter.searchQuery.isBlank() ||
-                item.title.contains(filter.searchQuery, ignoreCase = true)
+    ): FilteredNews {
+        val matcher = NewsSearchMatcher.parse(filter.searchQuery)
+        val filteredNews = news.filter { item ->
             val unreadMatches = !filter.unreadOnly || item.unread
             val categoryMatches = filter.selectedCategories.isEmpty() ||
                 item.category in filter.selectedCategories
-            val authorMatches = filter.selectedAuthors.isEmpty() ||
-                item.domain in filter.selectedAuthors
 
-            queryMatches && unreadMatches && categoryMatches && authorMatches
+            matcher.matches(item) && unreadMatches && categoryMatches
         }
+        return FilteredNews(filteredNews, matcher.error)
     }
 
-    private companion object {
-        const val UNKNOWN_AUTHOR = "掲載元不明"
+    private fun Set<String>.areAllRead(): Boolean {
+        if (isEmpty()) return false
+        val selectedItems = allNews.filter { it.newsId in this }
+        return selectedItems.size == size && selectedItems.all { !it.unread }
     }
+
+    private data class FilteredNews(
+        val items: List<NewsItem>,
+        val error: String?
+    )
+}
+
+private fun Set<String>.toggle(value: String): Set<String> {
+    return if (value in this) this - value else this + value
 }


### PR DESCRIPTION
## 変更内容

### お知らせ検索

- タイトルと発信元を1つの検索バーで横断検索
- 通常検索でも次の検索構文を利用可能
  - `"完全一致フレーズ"`
  - `-除外語`
  - `OR`
  - 括弧によるグループ化
  - `since:YYYY-MM-DD`
  - `until:YYYY-MM-DD`
  - `title:(...)`
  - `author:(...)`
- `title:` と `author:` は検索範囲を明確にするため括弧を必須化
- 検索バー横に詳細検索ボタンを追加
- 詳細検索GUIからAND、完全一致、OR、除外、タイトル、発信元、開始日、終了日を検索式へ変換
- 検索構文エラーを検索欄の下に表示
- 「未読のみ」と「カテゴリ」フィルターは維持
- LMS以外を含む全お知らせで発信元を表示・検索

### 選択と既読状態

- 通常時の「選択」「すべて既読」ボタンを削除
- お知らせの長押しで選択モードを開始
- 選択後に「全て選択」「既読／未読」「選択終了」を表示
- 選択項目がすべて既読なら操作ボタンを「未読」に変更
- 既読／未読状態はローカルRoomデータベースへ保存

### その他

- S*gsotクイックリンクをCITRUSへ変更
- CITRUS URLを `https://sitrus.sic.shibaura-it.ac.jp/SITRUS/login/index.html?N=<学籍番号>` 形式で生成
- リポジトリ直下に `SCOMBZ_API.md` を追加
- ScombZ Mobile APIのBase URL、Bearer認証、エンドポイント、JSON項目、Base64処理、日時形式をクライアント実装に基づいて記載
- `/home/{yearMonth}` の応答形式など未解析部分は未確認として明記

## 確認

- mainとの差分と競合なし
- Android CI: `./gradlew assembleDebug testDebugUnitTest -x lint`
- ビルド、単体テスト、APK生成成功
