### PR TITLE
Add news notification toggle

### DIFF
--- a/.github/workflows/apply-news-notification-toggle.yml
+++ b/.github/workflows/apply-news-notification-toggle.yml
@@ -1,0 +1,336 @@
+name: Apply news notification toggle
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - .github/workflows/apply-news-notification-toggle.yml
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Apply source changes
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          def replace_once(path: str, old: str, new: str) -> None:
+              file = Path(path)
+              text = file.read_text()
+              if text.count(old) != 1:
+                  raise RuntimeError(f"Expected one match in {path}, found {text.count(old)}")
+              file.write_text(text.replace(old, new, 1))
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt",
+              '''        val NOTIFICATION_TIMINGS_KEY = stringSetPreferencesKey("notification_timings")
+                  val DEFAULT_TIMINGS = setOf("60")''',
+              '''        val NOTIFICATION_TIMINGS_KEY = stringSetPreferencesKey("notification_timings")
+                  val DEFAULT_TIMINGS = setOf("60")
+
+                  val NEWS_NOTIFICATIONS_ENABLED_KEY = booleanPreferencesKey("news_notifications_enabled")
+                  const val DEFAULT_NEWS_NOTIFICATIONS_ENABLED = true'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt",
+              '''    val notificationTimingsFlow: Flow<Set<String>> = context.settingsDataStore.data.map { preferences ->
+                  preferences[NOTIFICATION_TIMINGS_KEY] ?: DEFAULT_TIMINGS
+              }
+
+              suspend fun setNotificationTimings(timings: Set<String>) {
+                  context.settingsDataStore.edit { preferences ->
+                      preferences[NOTIFICATION_TIMINGS_KEY] = timings
+                  }
+              }''',
+              '''    val notificationTimingsFlow: Flow<Set<String>> = context.settingsDataStore.data.map { preferences ->
+                  preferences[NOTIFICATION_TIMINGS_KEY] ?: DEFAULT_TIMINGS
+              }
+
+              suspend fun setNotificationTimings(timings: Set<String>) {
+                  context.settingsDataStore.edit { preferences ->
+                      preferences[NOTIFICATION_TIMINGS_KEY] = timings
+                  }
+              }
+
+              val newsNotificationsEnabledFlow: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->
+                  preferences[NEWS_NOTIFICATIONS_ENABLED_KEY] ?: DEFAULT_NEWS_NOTIFICATIONS_ENABLED
+              }
+
+              suspend fun setNewsNotificationsEnabled(enabled: Boolean) {
+                  context.settingsDataStore.edit { preferences ->
+                      preferences[NEWS_NOTIFICATIONS_ENABLED_KEY] = enabled
+                  }
+              }'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
+              '''data class SettingsUiState(
+                  val notificationTimings: Set<Int> = emptySet(),
+                  val showHomeNews: Boolean = true,''',
+              '''data class SettingsUiState(
+                  val notificationTimings: Set<Int> = emptySet(),
+                  val newsNotificationsEnabled: Boolean = true,
+                  val showHomeNews: Boolean = true,'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
+              '''    // 6つのFlowを結合するために、下部で定義した拡張combine関数を使用します
+              val uiState: StateFlow<SettingsUiState> = combine(
+                  settingsManager.notificationTimingsFlow,
+                  settingsManager.showHomeNewsFlow,
+                  settingsManager.debugModeFlow,
+                  settingsManager.displayWeekDaysFlow,
+                  settingsManager.timetablePeriodCountFlow,
+                  settingsManager.themeModeFlow
+              ) { timings, showNews, debugMode, weekDays, periodCount, themeMode ->
+                  SettingsUiState(
+                      notificationTimings = timings.mapNotNull { it.toIntOrNull() }.toSet(),
+                      showHomeNews = showNews,''',
+              '''    // 7つのFlowを結合するために、下部で定義した拡張combine関数を使用します
+              val uiState: StateFlow<SettingsUiState> = combine(
+                  settingsManager.notificationTimingsFlow,
+                  settingsManager.newsNotificationsEnabledFlow,
+                  settingsManager.showHomeNewsFlow,
+                  settingsManager.debugModeFlow,
+                  settingsManager.displayWeekDaysFlow,
+                  settingsManager.timetablePeriodCountFlow,
+                  settingsManager.themeModeFlow
+              ) { timings, newsNotificationsEnabled, showNews, debugMode, weekDays, periodCount, themeMode ->
+                  SettingsUiState(
+                      notificationTimings = timings.mapNotNull { it.toIntOrNull() }.toSet(),
+                      newsNotificationsEnabled = newsNotificationsEnabled,
+                      showHomeNews = showNews,'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
+              '''    fun updateNotificationTimings(timings: Set<Int>) {
+                  viewModelScope.launch {
+                      settingsManager.setNotificationTimings(timings.map { it.toString() }.toSet())
+                  }
+              }
+
+              fun updateShowHomeNews(show: Boolean) {''',
+              '''    fun updateNotificationTimings(timings: Set<Int>) {
+                  viewModelScope.launch {
+                      settingsManager.setNotificationTimings(timings.map { it.toString() }.toSet())
+                  }
+              }
+
+              fun updateNewsNotificationsEnabled(enabled: Boolean) {
+                  viewModelScope.launch {
+                      settingsManager.setNewsNotificationsEnabled(enabled)
+                  }
+              }
+
+              fun updateShowHomeNews(show: Boolean) {'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
+              '''@Suppress("UNCHECKED_CAST")
+              fun <T1, T2, T3, T4, T5, T6, R> combine(
+                  flow1: Flow<T1>,
+                  flow2: Flow<T2>,
+                  flow3: Flow<T3>,
+                  flow4: Flow<T4>,
+                  flow5: Flow<T5>,
+                  flow6: Flow<T6>,
+                  transform: suspend (T1, T2, T3, T4, T5, T6) -> R
+              ): Flow<R> = combine(listOf(flow1, flow2, flow3, flow4, flow5, flow6)) { args ->
+                  transform(
+                      args[0] as T1,
+                      args[1] as T2,
+                      args[2] as T3,
+                      args[3] as T4,
+                      args[4] as T5,
+                      args[5] as T6
+                  )
+              }''',
+              '''@Suppress("UNCHECKED_CAST")
+              fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
+                  flow1: Flow<T1>,
+                  flow2: Flow<T2>,
+                  flow3: Flow<T3>,
+                  flow4: Flow<T4>,
+                  flow5: Flow<T5>,
+                  flow6: Flow<T6>,
+                  flow7: Flow<T7>,
+                  transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R
+              ): Flow<R> = combine(listOf(flow1, flow2, flow3, flow4, flow5, flow6, flow7)) { args ->
+                  transform(
+                      args[0] as T1,
+                      args[1] as T2,
+                      args[2] as T3,
+                      args[3] as T4,
+                      args[4] as T5,
+                      args[5] as T6,
+                      args[6] as T7
+                  )
+              }'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt",
+              '''                NotificationSettingsSection(
+                      selectedTimings = uiState.notificationTimings,
+                      onTimingsChange = { viewModel.updateNotificationTimings(it) }
+                  )''',
+              '''                NotificationSettingsSection(
+                      newsNotificationsEnabled = uiState.newsNotificationsEnabled,
+                      onNewsNotificationsEnabledChange = { viewModel.updateNewsNotificationsEnabled(it) },
+                      selectedTimings = uiState.notificationTimings,
+                      onTimingsChange = { viewModel.updateNotificationTimings(it) }
+                  )'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt",
+              '''private fun NotificationSettingsSection(
+                  selectedTimings: Set<Int>,
+                  onTimingsChange: (Set<Int>) -> Unit
+              ) {''',
+              '''private fun NotificationSettingsSection(
+                  newsNotificationsEnabled: Boolean,
+                  onNewsNotificationsEnabledChange: (Boolean) -> Unit,
+                  selectedTimings: Set<Int>,
+                  onTimingsChange: (Set<Int>) -> Unit
+              ) {'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt",
+              '''        SectionHeader(
+                      title = stringResource(R.string.settings_notification_title),
+                      icon = Icons.Default.Notifications
+                  )
+
+                  Text(
+                      text = stringResource(R.string.settings_notification_desc),''',
+              '''        SectionHeader(
+                      title = stringResource(R.string.settings_notification_title),
+                      icon = Icons.Default.Notifications
+                  )
+
+                  Row(
+                      modifier = Modifier.fillMaxWidth(),
+                      horizontalArrangement = Arrangement.SpaceBetween,
+                      verticalAlignment = Alignment.CenterVertically
+                  ) {
+                      Column(modifier = Modifier.weight(1f)) {
+                          Text(
+                              text = "お知らせ通知",
+                              style = MaterialTheme.typography.bodyLarge
+                          )
+                          Text(
+                              text = "ScombZから届くお知らせを通知します",
+                              style = MaterialTheme.typography.bodySmall,
+                              color = MaterialTheme.colorScheme.onSurfaceVariant
+                          )
+                      }
+                      Switch(
+                          checked = newsNotificationsEnabled,
+                          onCheckedChange = onNewsNotificationsEnabledChange
+                      )
+                  }
+
+                  Spacer(modifier = Modifier.height(20.dp))
+
+                  Text(
+                      text = "課題の締切通知",
+                      style = MaterialTheme.typography.bodyLarge,
+                      fontWeight = FontWeight.Medium,
+                      modifier = Modifier.padding(bottom = 4.dp)
+                  )
+
+                  Text(
+                      text = stringResource(R.string.settings_notification_desc),'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
+              '''import com.atuy.scomb.R
+              import com.atuy.scomb.data.repository.ScombzRepository''',
+              '''import com.atuy.scomb.R
+              import com.atuy.scomb.data.manager.SettingsManager
+              import com.atuy.scomb.data.repository.ScombzRepository'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
+              '''import kotlinx.coroutines.SupervisorJob
+              import kotlinx.coroutines.launch''',
+              '''import kotlinx.coroutines.SupervisorJob
+              import kotlinx.coroutines.flow.first
+              import kotlinx.coroutines.launch'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
+              '''    @Inject
+              lateinit var scombzRepository: ScombzRepository
+
+              private val serviceScope''',
+              '''    @Inject
+              lateinit var scombzRepository: ScombzRepository
+
+              @Inject
+              lateinit var settingsManager: SettingsManager
+
+              private val serviceScope'''
+          )
+
+          replace_once(
+              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
+              '''        showNewsNotification(title, body, newsUrl)
+              }''',
+              '''        serviceScope.launch {
+                  if (!settingsManager.newsNotificationsEnabledFlow.first()) {
+                      AppLogger.d("News notifications disabled; skipping notification")
+                      return@launch
+                  }
+                  showNewsNotification(title, body, newsUrl)
+              }
+              }'''
+          )
+          PY
+
+          rm .github/workflows/apply-news-notification-toggle.yml
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build and test
+        run: |
+          chmod +x gradlew
+          ./gradlew assembleDebug testDebugUnitTest -x lint
+
+      - name: Commit changes
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt \
+            app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt \
+            app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt \
+            app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt \
+            .github/workflows/apply-news-notification-toggle.yml
+          git commit -m "Add news notification toggle"
+          git push origin HEAD:dev

--- a/.github/workflows/apply-news-notification-toggle.yml
+++ b/.github/workflows/apply-news-notification-toggle.yml
@@ -1,11 +1,6 @@
 name: Apply news notification toggle
 
 on:
-  push:
-    branches:
-      - dev
-    paths:
-      - .github/workflows/apply-news-notification-toggle.yml
   pull_request:
     branches:
       - main
@@ -24,7 +19,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: dev
-          fetch-depth: 0
+          fetch-depth: 1
+          show-progress: false
 
       - name: Apply source changes
         shell: bash
@@ -32,287 +28,192 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
 
-          def replace_once(path: str, old: str, new: str) -> None:
+          def replace(path: str, old: str, new: str) -> None:
               file = Path(path)
               text = file.read_text()
-              if text.count(old) != 1:
-                  raise RuntimeError(f"Expected one match in {path}, found {text.count(old)}")
+              count = text.count(old)
+              print(f"{path}: {old.splitlines()[0]!r} -> {count} match(es)")
+              if count != 1:
+                  raise RuntimeError(f"Expected one match in {path}, found {count}")
               file.write_text(text.replace(old, new, 1))
 
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt",
-              '''        val NOTIFICATION_TIMINGS_KEY = stringSetPreferencesKey("notification_timings")
-                  val DEFAULT_TIMINGS = setOf("60")''',
-              '''        val NOTIFICATION_TIMINGS_KEY = stringSetPreferencesKey("notification_timings")
-                  val DEFAULT_TIMINGS = setOf("60")
-
-                  val NEWS_NOTIFICATIONS_ENABLED_KEY = booleanPreferencesKey("news_notifications_enabled")
-                  const val DEFAULT_NEWS_NOTIFICATIONS_ENABLED = true'''
+          manager = "app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt"
+          replace(
+              manager,
+              '        val DEFAULT_TIMINGS = setOf("60")',
+              '        val DEFAULT_TIMINGS = setOf("60")\n\n'
+              '        val NEWS_NOTIFICATIONS_ENABLED_KEY = booleanPreferencesKey("news_notifications_enabled")\n'
+              '        const val DEFAULT_NEWS_NOTIFICATIONS_ENABLED = true'
+          )
+          replace(
+              manager,
+              '    val showHomeNewsFlow: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->',
+              '    val newsNotificationsEnabledFlow: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->\n'
+              '        preferences[NEWS_NOTIFICATIONS_ENABLED_KEY] ?: DEFAULT_NEWS_NOTIFICATIONS_ENABLED\n'
+              '    }\n\n'
+              '    suspend fun setNewsNotificationsEnabled(enabled: Boolean) {\n'
+              '        context.settingsDataStore.edit { preferences ->\n'
+              '            preferences[NEWS_NOTIFICATIONS_ENABLED_KEY] = enabled\n'
+              '        }\n'
+              '    }\n\n'
+              '    val showHomeNewsFlow: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->'
           )
 
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt",
-              '''    val notificationTimingsFlow: Flow<Set<String>> = context.settingsDataStore.data.map { preferences ->
-                  preferences[NOTIFICATION_TIMINGS_KEY] ?: DEFAULT_TIMINGS
-              }
-
-              suspend fun setNotificationTimings(timings: Set<String>) {
-                  context.settingsDataStore.edit { preferences ->
-                      preferences[NOTIFICATION_TIMINGS_KEY] = timings
-                  }
-              }''',
-              '''    val notificationTimingsFlow: Flow<Set<String>> = context.settingsDataStore.data.map { preferences ->
-                  preferences[NOTIFICATION_TIMINGS_KEY] ?: DEFAULT_TIMINGS
-              }
-
-              suspend fun setNotificationTimings(timings: Set<String>) {
-                  context.settingsDataStore.edit { preferences ->
-                      preferences[NOTIFICATION_TIMINGS_KEY] = timings
-                  }
-              }
-
-              val newsNotificationsEnabledFlow: Flow<Boolean> = context.settingsDataStore.data.map { preferences ->
-                  preferences[NEWS_NOTIFICATIONS_ENABLED_KEY] ?: DEFAULT_NEWS_NOTIFICATIONS_ENABLED
-              }
-
-              suspend fun setNewsNotificationsEnabled(enabled: Boolean) {
-                  context.settingsDataStore.edit { preferences ->
-                      preferences[NEWS_NOTIFICATIONS_ENABLED_KEY] = enabled
-                  }
-              }'''
+          view_model = "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt"
+          replace(
+              view_model,
+              '    val notificationTimings: Set<Int> = emptySet(),',
+              '    val notificationTimings: Set<Int> = emptySet(),\n'
+              '    val newsNotificationsEnabled: Boolean = true,'
+          )
+          replace(
+              view_model,
+              '    // 6つのFlowを結合するために、下部で定義した拡張combine関数を使用します',
+              '    // 7つのFlowを結合するために、下部で定義した拡張combine関数を使用します'
+          )
+          replace(
+              view_model,
+              '        settingsManager.notificationTimingsFlow,',
+              '        settingsManager.notificationTimingsFlow,\n'
+              '        settingsManager.newsNotificationsEnabledFlow,'
+          )
+          replace(
+              view_model,
+              '    ) { timings, showNews, debugMode, weekDays, periodCount, themeMode ->',
+              '    ) { timings, newsNotificationsEnabled, showNews, debugMode, weekDays, periodCount, themeMode ->'
+          )
+          replace(
+              view_model,
+              '            notificationTimings = timings.mapNotNull { it.toIntOrNull() }.toSet(),',
+              '            notificationTimings = timings.mapNotNull { it.toIntOrNull() }.toSet(),\n'
+              '            newsNotificationsEnabled = newsNotificationsEnabled,'
+          )
+          replace(
+              view_model,
+              '    fun updateShowHomeNews(show: Boolean) {',
+              '    fun updateNewsNotificationsEnabled(enabled: Boolean) {\n'
+              '        viewModelScope.launch {\n'
+              '            settingsManager.setNewsNotificationsEnabled(enabled)\n'
+              '        }\n'
+              '    }\n\n'
+              '    fun updateShowHomeNews(show: Boolean) {'
+          )
+          replace(
+              view_model,
+              'fun <T1, T2, T3, T4, T5, T6, R> combine(',
+              'fun <T1, T2, T3, T4, T5, T6, T7, R> combine('
+          )
+          replace(
+              view_model,
+              '    flow6: Flow<T6>,',
+              '    flow6: Flow<T6>,\n    flow7: Flow<T7>,'
+          )
+          replace(
+              view_model,
+              '    transform: suspend (T1, T2, T3, T4, T5, T6) -> R',
+              '    transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R'
+          )
+          replace(
+              view_model,
+              '): Flow<R> = combine(listOf(flow1, flow2, flow3, flow4, flow5, flow6)) { args ->',
+              '): Flow<R> = combine(listOf(flow1, flow2, flow3, flow4, flow5, flow6, flow7)) { args ->'
+          )
+          replace(
+              view_model,
+              '        args[5] as T6',
+              '        args[5] as T6,\n        args[6] as T7'
           )
 
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
-              '''data class SettingsUiState(
-                  val notificationTimings: Set<Int> = emptySet(),
-                  val showHomeNews: Boolean = true,''',
-              '''data class SettingsUiState(
-                  val notificationTimings: Set<Int> = emptySet(),
-                  val newsNotificationsEnabled: Boolean = true,
-                  val showHomeNews: Boolean = true,'''
+          screen = "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt"
+          replace(
+              screen,
+              '                NotificationSettingsSection(\n                    selectedTimings = uiState.notificationTimings,',
+              '                NotificationSettingsSection(\n'
+              '                    newsNotificationsEnabled = uiState.newsNotificationsEnabled,\n'
+              '                    onNewsNotificationsEnabledChange = { viewModel.updateNewsNotificationsEnabled(it) },\n'
+              '                    selectedTimings = uiState.notificationTimings,'
           )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
-              '''    // 6つのFlowを結合するために、下部で定義した拡張combine関数を使用します
-              val uiState: StateFlow<SettingsUiState> = combine(
-                  settingsManager.notificationTimingsFlow,
-                  settingsManager.showHomeNewsFlow,
-                  settingsManager.debugModeFlow,
-                  settingsManager.displayWeekDaysFlow,
-                  settingsManager.timetablePeriodCountFlow,
-                  settingsManager.themeModeFlow
-              ) { timings, showNews, debugMode, weekDays, periodCount, themeMode ->
-                  SettingsUiState(
-                      notificationTimings = timings.mapNotNull { it.toIntOrNull() }.toSet(),
-                      showHomeNews = showNews,''',
-              '''    // 7つのFlowを結合するために、下部で定義した拡張combine関数を使用します
-              val uiState: StateFlow<SettingsUiState> = combine(
-                  settingsManager.notificationTimingsFlow,
-                  settingsManager.newsNotificationsEnabledFlow,
-                  settingsManager.showHomeNewsFlow,
-                  settingsManager.debugModeFlow,
-                  settingsManager.displayWeekDaysFlow,
-                  settingsManager.timetablePeriodCountFlow,
-                  settingsManager.themeModeFlow
-              ) { timings, newsNotificationsEnabled, showNews, debugMode, weekDays, periodCount, themeMode ->
-                  SettingsUiState(
-                      notificationTimings = timings.mapNotNull { it.toIntOrNull() }.toSet(),
-                      newsNotificationsEnabled = newsNotificationsEnabled,
-                      showHomeNews = showNews,'''
+          replace(
+              screen,
+              'private fun NotificationSettingsSection(\n    selectedTimings: Set<Int>,',
+              'private fun NotificationSettingsSection(\n'
+              '    newsNotificationsEnabled: Boolean,\n'
+              '    onNewsNotificationsEnabledChange: (Boolean) -> Unit,\n'
+              '    selectedTimings: Set<Int>,'
           )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
-              '''    fun updateNotificationTimings(timings: Set<Int>) {
-                  viewModelScope.launch {
-                      settingsManager.setNotificationTimings(timings.map { it.toString() }.toSet())
-                  }
-              }
-
-              fun updateShowHomeNews(show: Boolean) {''',
-              '''    fun updateNotificationTimings(timings: Set<Int>) {
-                  viewModelScope.launch {
-                      settingsManager.setNotificationTimings(timings.map { it.toString() }.toSet())
-                  }
-              }
-
-              fun updateNewsNotificationsEnabled(enabled: Boolean) {
-                  viewModelScope.launch {
-                      settingsManager.setNewsNotificationsEnabled(enabled)
-                  }
-              }
-
-              fun updateShowHomeNews(show: Boolean) {'''
+          notification_function = screen
+          file = Path(notification_function)
+          text = file.read_text()
+          start = text.index('private fun NotificationSettingsSection(')
+          marker = '''        SectionHeader(
+              title = stringResource(R.string.settings_notification_title),
+              icon = Icons.Default.Notifications
           )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt",
-              '''@Suppress("UNCHECKED_CAST")
-              fun <T1, T2, T3, T4, T5, T6, R> combine(
-                  flow1: Flow<T1>,
-                  flow2: Flow<T2>,
-                  flow3: Flow<T3>,
-                  flow4: Flow<T4>,
-                  flow5: Flow<T5>,
-                  flow6: Flow<T6>,
-                  transform: suspend (T1, T2, T3, T4, T5, T6) -> R
-              ): Flow<R> = combine(listOf(flow1, flow2, flow3, flow4, flow5, flow6)) { args ->
-                  transform(
-                      args[0] as T1,
-                      args[1] as T2,
-                      args[2] as T3,
-                      args[3] as T4,
-                      args[4] as T5,
-                      args[5] as T6
-                  )
-              }''',
-              '''@Suppress("UNCHECKED_CAST")
-              fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
-                  flow1: Flow<T1>,
-                  flow2: Flow<T2>,
-                  flow3: Flow<T3>,
-                  flow4: Flow<T4>,
-                  flow5: Flow<T5>,
-                  flow6: Flow<T6>,
-                  flow7: Flow<T7>,
-                  transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R
-              ): Flow<R> = combine(listOf(flow1, flow2, flow3, flow4, flow5, flow6, flow7)) { args ->
-                  transform(
-                      args[0] as T1,
-                      args[1] as T2,
-                      args[2] as T3,
-                      args[3] as T4,
-                      args[4] as T5,
-                      args[5] as T6,
-                      args[6] as T7
-                  )
-              }'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt",
-              '''                NotificationSettingsSection(
-                      selectedTimings = uiState.notificationTimings,
-                      onTimingsChange = { viewModel.updateNotificationTimings(it) }
-                  )''',
-              '''                NotificationSettingsSection(
-                      newsNotificationsEnabled = uiState.newsNotificationsEnabled,
-                      onNewsNotificationsEnabledChange = { viewModel.updateNewsNotificationsEnabled(it) },
-                      selectedTimings = uiState.notificationTimings,
-                      onTimingsChange = { viewModel.updateNotificationTimings(it) }
-                  )'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt",
-              '''private fun NotificationSettingsSection(
-                  selectedTimings: Set<Int>,
-                  onTimingsChange: (Set<Int>) -> Unit
-              ) {''',
-              '''private fun NotificationSettingsSection(
-                  newsNotificationsEnabled: Boolean,
-                  onNewsNotificationsEnabledChange: (Boolean) -> Unit,
-                  selectedTimings: Set<Int>,
-                  onTimingsChange: (Set<Int>) -> Unit
-              ) {'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt",
-              '''        SectionHeader(
-                      title = stringResource(R.string.settings_notification_title),
-                      icon = Icons.Default.Notifications
-                  )
-
+'''
+          local_index = text.index(marker, start)
+          insert_at = local_index + len(marker)
+          addition = '''
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically
+          ) {
+              Column(modifier = Modifier.weight(1f)) {
                   Text(
-                      text = stringResource(R.string.settings_notification_desc),''',
-              '''        SectionHeader(
-                      title = stringResource(R.string.settings_notification_title),
-                      icon = Icons.Default.Notifications
+                      text = "お知らせ通知",
+                      style = MaterialTheme.typography.bodyLarge
                   )
-
-                  Row(
-                      modifier = Modifier.fillMaxWidth(),
-                      horizontalArrangement = Arrangement.SpaceBetween,
-                      verticalAlignment = Alignment.CenterVertically
-                  ) {
-                      Column(modifier = Modifier.weight(1f)) {
-                          Text(
-                              text = "お知らせ通知",
-                              style = MaterialTheme.typography.bodyLarge
-                          )
-                          Text(
-                              text = "ScombZから届くお知らせを通知します",
-                              style = MaterialTheme.typography.bodySmall,
-                              color = MaterialTheme.colorScheme.onSurfaceVariant
-                          )
-                      }
-                      Switch(
-                          checked = newsNotificationsEnabled,
-                          onCheckedChange = onNewsNotificationsEnabledChange
-                      )
-                  }
-
-                  Spacer(modifier = Modifier.height(20.dp))
-
                   Text(
-                      text = "課題の締切通知",
-                      style = MaterialTheme.typography.bodyLarge,
-                      fontWeight = FontWeight.Medium,
-                      modifier = Modifier.padding(bottom = 4.dp)
+                      text = "ScombZから届くお知らせを通知します",
+                      style = MaterialTheme.typography.bodySmall,
+                      color = MaterialTheme.colorScheme.onSurfaceVariant
                   )
-
-                  Text(
-                      text = stringResource(R.string.settings_notification_desc),'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
-              '''import com.atuy.scomb.R
-              import com.atuy.scomb.data.repository.ScombzRepository''',
-              '''import com.atuy.scomb.R
-              import com.atuy.scomb.data.manager.SettingsManager
-              import com.atuy.scomb.data.repository.ScombzRepository'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
-              '''import kotlinx.coroutines.SupervisorJob
-              import kotlinx.coroutines.launch''',
-              '''import kotlinx.coroutines.SupervisorJob
-              import kotlinx.coroutines.flow.first
-              import kotlinx.coroutines.launch'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
-              '''    @Inject
-              lateinit var scombzRepository: ScombzRepository
-
-              private val serviceScope''',
-              '''    @Inject
-              lateinit var scombzRepository: ScombzRepository
-
-              @Inject
-              lateinit var settingsManager: SettingsManager
-
-              private val serviceScope'''
-          )
-
-          replace_once(
-              "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt",
-              '''        showNewsNotification(title, body, newsUrl)
-              }''',
-              '''        serviceScope.launch {
-                  if (!settingsManager.newsNotificationsEnabledFlow.first()) {
-                      AppLogger.d("News notifications disabled; skipping notification")
-                      return@launch
-                  }
-                  showNewsNotification(title, body, newsUrl)
               }
-              }'''
+              Switch(
+                  checked = newsNotificationsEnabled,
+                  onCheckedChange = onNewsNotificationsEnabledChange
+              )
+          }
+
+          Spacer(modifier = Modifier.height(20.dp))
+
+          Text(
+              text = "課題の締切通知",
+              style = MaterialTheme.typography.bodyLarge,
+              fontWeight = FontWeight.Medium,
+              modifier = Modifier.padding(bottom = 4.dp)
+          )
+'''
+          file.write_text(text[:insert_at] + addition + text[insert_at:])
+
+          service = "app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt"
+          replace(
+              service,
+              'import com.atuy.scomb.R\n',
+              'import com.atuy.scomb.R\nimport com.atuy.scomb.data.manager.SettingsManager\n'
+          )
+          replace(
+              service,
+              'import kotlinx.coroutines.SupervisorJob\n',
+              'import kotlinx.coroutines.SupervisorJob\nimport kotlinx.coroutines.flow.first\n'
+          )
+          replace(
+              service,
+              '    lateinit var scombzRepository: ScombzRepository\n',
+              '    lateinit var scombzRepository: ScombzRepository\n\n'
+              '    @Inject\n'
+              '    lateinit var settingsManager: SettingsManager\n'
+          )
+          replace(
+              service,
+              '        showNewsNotification(title, body, newsUrl)',
+              '        serviceScope.launch {\n'
+              '            if (!settingsManager.newsNotificationsEnabledFlow.first()) {\n'
+              '                AppLogger.d("News notifications disabled; skipping notification")\n'
+              '                return@launch\n'
+              '            }\n'
+              '            showNewsNotification(title, body, newsUrl)\n'
+              '        }'
           )
           PY
 
@@ -333,11 +234,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add \
-            app/src/main/java/com/atuy/scomb/data/manager/SettingManager.kt \
-            app/src/main/java/com/atuy/scomb/ui/viewmodel/SettingsViewModel.kt \
-            app/src/main/java/com/atuy/scomb/ui/features/SettingsScreen.kt \
-            app/src/main/java/com/atuy/scomb/service/ScombMessagingService.kt \
-            .github/workflows/apply-news-notification-toggle.yml
+          git add -A
           git commit -m "Add news notification toggle"
           git push origin HEAD:dev

--- a/.github/workflows/apply-news-notification-toggle.yml
+++ b/.github/workflows/apply-news-notification-toggle.yml
@@ -6,6 +6,13 @@ on:
       - dev
     paths:
       - .github/workflows/apply-news-notification-toggle.yml
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions:
   contents: write


### PR DESCRIPTION
## 変更内容

- 設定画面にお知らせ通知のオン・オフを追加
- 設定をDataStoreへ保存
- オフの場合はFCMメッセージを受信してもAndroid通知を表示しない
- 課題締切通知の設定とは分離

## 実装方針

公式アプリの切替ログではFCM登録・解除に相当する通信を確認できなかったため、トークン登録は維持し、通知表示のみを抑止します。

## 確認

- `./gradlew assembleDebug testDebugUnitTest -x lint`